### PR TITLE
Cheeky edits to 06-entity-&-operations.md

### DIFF
--- a/docs/06-entity-&-operations.md
+++ b/docs/06-entity-&-operations.md
@@ -1,15 +1,28 @@
-# 6. Entity & Operations Funding
+# 6. Entity & Operations
 
-There is a PG legal entity which currently receives 2% of the split proceeds to a Safe multisig:
+## 6.1 Legal Structure
 
-- [0x0cDF1a78f00f56ba879D0aCc0FDa1789e415f23B](https://app.safe.global/balances?safe=eth:0x0cDF1a78f00f56ba879D0aCc0FDa1789e415f23B) (current address)
-- [0x69f4b27882eD6dc39E820acFc08C3d14f8e98a99](https://app.safe.global/balances?safe=eth:0x69f4b27882eD6dc39E820acFc08C3d14f8e98a99) (previous address)
+*Coming soon*
+
+## 6.2 Finances
+
+Protocol Guild's legal entity currently receives 2% of split proceeds to Safe multisigs:
+
+- Mainnet
+    - [0x0cDF1a78f00f56ba879D0aCc0FDa1789e415f23B](https://app.safe.global/balances?safe=eth:0x0cDF1a78f00f56ba879D0aCc0FDa1789e415f23B) (current address)
+    - [0x69f4b27882eD6dc39E820acFc08C3d14f8e98a99](https://app.safe.global/balances?safe=eth:0x69f4b27882eD6dc39E820acFc08C3d14f8e98a99) (previous address)
+- Optimism
+    - [0x0cDF1a78f00f56ba879D0aCc0FDa1789e415f23B](https://app.safe.global/balances?safe=oeth:0x0cDF1a78f00f56ba879D0aCc0FDa1789e415f23B)
 
 The entity converts all tokens on a monthly basis to maintain a stablecoin reserve. This covers:
 
-- $200k in reserve for 2 years of fixed annual/variable expenses incurred to operate the entity, hedge market volatility, and any unanticipated expenses
+- $200k in reserve for 2 years of fixed + variable costs incurred to operate the entity
 - $100k in reserve for potential insurance claims against the foundation 
-- stable base compensation for independent Operations contributors
-    - $12.5k/month ($150k/year) to support Cheeky Gorilla's ongoing full-time contributions
+- Stable base compensation for independent Operations contributors
+    - $12.5k/month ($150k/year) to support cheeky-gorilla's ongoing full-time contributions
 
 Generally, the entity should receive sufficient funding to cover the above, but not accumulate beyond that. These amounts are set by the membership, as noted in the [Governance](https://protocol-guild.readthedocs.io/en/latest/02-membership.html#governance) subsection of the docs.
+
+## 6.3 Quarterly Reports
+
+*Coming soon*


### PR DESCRIPTION
Made it more future proof by;

- Renaming section title to simply "Entity & Operations" instead of "Entity & Operations Funding", because if we do fill out this section with more info in the future, then having a more broad name is better because changing this title would break links shared in the past
- Added placeholders for sections we'll add in the future
- Adding blockchain categories (added Optimism, and we'll be adding zkSync soon too)

Other small changes;

- Changed my name for consistency (to match the membership table)
- Simplified the "$200k" sentence ("hedge market volatility" is covered by "maintaing stablecoin reserve" and "unanticipated expenses" is covered by "variable costs")